### PR TITLE
allows overriding the controller names for which the stripe headers a…

### DIFF
--- a/stripe_official.php
+++ b/stripe_official.php
@@ -1058,7 +1058,9 @@ class Stripe_official extends PaymentModule
      */
     public function hookHeader()
     {
-        if (!in_array($this->context->controller->php_self, ['order', 'order-opc'])) {
+        $orderPageNames = ['order', 'order-opc'];
+        Hook::exec('actionStripeDefineOrderPageNames', array('orderPageNames' => &$orderPageNames));
+        if (!in_array(Tools::getvalue('controller'), $orderPageNames)) {
             return;
         }
 


### PR DESCRIPTION
 allows overriding the controller names for which the stripe headers are sent.

This eases integrating stripe with 3rd party one page checkout modules.

