### PR TITLE
Search for disputes with the correct API key, only if the order was paid by stripe. Solves issues #42 and #45.

### DIFF
--- a/classes/StripeDispute.php
+++ b/classes/StripeDispute.php
@@ -35,24 +35,25 @@ class StripeDispute extends ObjectModel
         $this->stripe_dispute_id = $stripe_dispute_id;
     }
 
-    public function getAllDisputes()
+    public function getAllDisputes($id_shop)
     {
         $module = Module::getInstanceByName('stripe_official');
+        $key = $module->getSecretKey($id_shop);
 
-        $stripe = new \Stripe\StripeClient(
-            $module->getSecretKey()
-        );
+        if(empty($key)) return false;
+
+        $stripe = new \Stripe\StripeClient($key);
 
         return $stripe->disputes->all();
     }
 
-    public function orderHasDispute($id_charge)
+    public function orderHasDispute($id_charge, $id_shop)
     {
-        $disputes = $this->getAllDisputes();
-
-        foreach ($disputes->data as $dispute) {
-            if ($dispute->charge == $id_charge) {
-                return true;
+        if($disputes = $this->getAllDisputes($id_shop)) {
+            foreach ($disputes->data as $dispute) {
+                if ($dispute->charge == $id_charge) {
+                    return true;
+                }
             }
         }
 

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -1190,14 +1190,15 @@ class Stripe_official extends PaymentModule
     /**
      * get Secret Key according MODE staging or live
      *
+     * @param null $id_shop Optional, if set, get the secret key of the specified shop
      * @return string
      */
-    public function getSecretKey()
+    public function getSecretKey($id_shop = null)
     {
-        if (Configuration::get(self::MODE)) {
-            return Configuration::get(self::TEST_KEY);
+        if (Configuration::get(self::MODE, null, null, $id_shop)) {
+            return Configuration::get(self::TEST_KEY, null, null, $id_shop);
         } else {
-            return Configuration::get(self::KEY);
+            return Configuration::get(self::KEY, null, null, $id_shop);
         }
     }
 
@@ -1357,7 +1358,7 @@ class Stripe_official extends PaymentModule
         $dispute = false;
         if(!empty($stripePayment->getIdStripe())) {
             $stripeDispute = new StripeDispute();
-            $dispute = $stripeDispute->orderHasDispute($stripePayment->getIdStripe());
+            $dispute = $stripeDispute->orderHasDispute($stripePayment->getIdStripe(), $params['order']->id_shop);
         }
 
         $this->context->smarty->assign(array(

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -1354,8 +1354,11 @@ class Stripe_official extends PaymentModule
         $stripeCapture = new StripeCapture();
         $stripeCapture->getByIdPaymentIntent($stripePayment->getIdPaymentIntent());
 
-        $stripeDispute = new StripeDispute();
-        $dispute = $stripeDispute->orderHasDispute($stripePayment->getIdStripe());
+        $dispute = false;
+        if(!empty($stripePayment->getIdStripe())) {
+            $stripeDispute = new StripeDispute();
+            $dispute = $stripeDispute->orderHasDispute($stripePayment->getIdStripe());
+        }
 
         $this->context->smarty->assign(array(
             'stripe_charge' => $stripePayment->getIdStripe(),


### PR DESCRIPTION
This merge request solves issues #42 and #45, that were introduced with commit [b3869de](https://github.com/202-ecommerce/stripe_official/commit/b3869ded912695e90247032b8088f10837494e3c).

- It fixes fatal error in BO in a multishop setup #42 
- It assures that the disputes are searched for in the stripe account corresponding to the current order #45
