### PR TITLE
Wrong capture_method for redirect payment

### DIFF
--- a/controllers/front/orderSuccess.php
+++ b/controllers/front/orderSuccess.php
@@ -200,8 +200,9 @@ class stripe_officialOrderSuccessModuleFrontController extends ModuleFrontContro
                 'addTentative'
             );
         } elseif (($eventType == 'pending' && $payment_method == 'sofort')
-            || (($eventType == 'succeeded' || $eventType == 'requires_action')
-                && Stripe_official::$paymentMethods[$payment_method]['flow'] == 'redirect')
+            || ($eventType == 'charge.succeeded'
+                && Stripe_official::$paymentMethods[$payment_method]['flow'] == 'redirect'
+                && $payment_method != 'sofort')
         ) {
             ProcessLoggerHandler::logInfo(
                 'Payment method flow with redirection',

--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -549,8 +549,9 @@ class stripe_officialWebhookModuleFrontController extends ModuleFrontController
                 'addTentative'
             );
         } elseif (($eventType == 'charge.pending' && $paymentMethodType == 'sofort')
-            || (($eventType == 'charge.succeeded' || $eventType == 'payment_intent.requires_action')
-                && Stripe_official::$paymentMethods[$paymentMethodType]['flow'] == 'redirect')
+            || ($eventType == 'charge.succeeded'
+                && Stripe_official::$paymentMethods[$paymentMethodType]['flow'] == 'redirect'
+                && $paymentMethodType != 'sofort')
         ) {
             ProcessLoggerHandler::logInfo(
                 'Payment method flow with redirection',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Impossible payment with SOFORT
| Type?         | regression
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #114 
| How to test?  | Payment with SoFort sould return a success payment