### PR TITLE
Fix date_add of stripe_event entries when status is CREATED

### DIFF
--- a/classes/StripeEvent.php
+++ b/classes/StripeEvent.php
@@ -139,6 +139,11 @@ class StripeEvent extends ObjectModel
         return $this->flow_type;
     }
 
+    public function save($null_values = false, $auto_date = false)
+    {
+        return parent::save($null_values, $auto_date);
+    }
+
     public function getLastRegisteredEventByPaymentIntent($paymentIntent)
     {
         $query = new DbQuery();

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -290,7 +290,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $stripeEvent = new StripeEvent();
             $stripeEvent->setIdPaymentIntent($intent->id);
             $stripeEvent->setStatus(StripeEvent::CREATED_STATUS);
-            $stripeEvent->setDateAdd($stripeEventDate);
+            $stripeEvent->setDateAdd($stripeEventDate->format('Y-m-d H:i:s'));
             $stripeEvent->setIsProcessed(1);
             $stripeEvent->setFlowType('direct');
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -66,7 +66,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
 
         ProcessLoggerHandler::logInfo(
@@ -77,7 +77,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
         );
         ProcessLoggerHandler::closeLogger();
 
-        $this->ajaxDie(
+        echo(
             json_encode([
                 'intent' => $intent,
                 'cardPayment' => $cardData['cardPayment'],
@@ -141,7 +141,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopDatabaseException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -151,7 +151,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -161,7 +161,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 
@@ -257,7 +257,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie($e->getMessage());
+            die($e->getMessage());
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Save Stripe Idempotency Key Error => ".$e->getMessage(),
@@ -267,7 +267,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Save Stripe Payment Intent Error => ".$e->getMessage(),
@@ -277,7 +277,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 
@@ -307,7 +307,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
                 );
                 ProcessLoggerHandler::closeLogger();
                 http_response_code(400);
-                $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+                die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
             }
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
@@ -318,7 +318,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -284,10 +284,13 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
     private function registerStripeEvent($intent)
     {
         try {
+            $stripeEventDate = new DateTime();
+            $stripeEventDate = $stripeEventDate->setTimestamp($intent->created);
+
             $stripeEvent = new StripeEvent();
             $stripeEvent->setIdPaymentIntent($intent->id);
             $stripeEvent->setStatus(StripeEvent::CREATED_STATUS);
-            $stripeEvent->setDateAdd($intent->created);
+            $stripeEvent->setDateAdd($stripeEventDate);
             $stripeEvent->setIsProcessed(1);
             $stripeEvent->setFlowType('direct');
 


### PR DESCRIPTION
The real date_add of the payment intent creation wasn't well saved by CREATED Stripe Event in stripe_event table.