### PR TITLE
Payment intent cannot be updated

### DIFF
--- a/classes/StripeEvent.php
+++ b/classes/StripeEvent.php
@@ -139,6 +139,11 @@ class StripeEvent extends ObjectModel
         return $this->flow_type;
     }
 
+    public function save($null_values = false, $auto_date = false)
+    {
+        return parent::save($null_values, $auto_date);
+    }
+
     public function getLastRegisteredEventByPaymentIntent($paymentIntent)
     {
         $query = new DbQuery();

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -290,7 +290,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $stripeEvent = new StripeEvent();
             $stripeEvent->setIdPaymentIntent($intent->id);
             $stripeEvent->setStatus(StripeEvent::CREATED_STATUS);
-            $stripeEvent->setDateAdd($stripeEventDate);
+            $stripeEvent->setDateAdd($stripeEventDate->format('Y-m-d H:i:s'));
             $stripeEvent->setIsProcessed(1);
             $stripeEvent->setFlowType('direct');
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -66,7 +66,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
 
         ProcessLoggerHandler::logInfo(
@@ -77,7 +77,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
         );
         ProcessLoggerHandler::closeLogger();
 
-        $this->ajaxDie(
+        echo(
             json_encode([
                 'intent' => $intent,
                 'cardPayment' => $cardData['cardPayment'],
@@ -141,7 +141,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopDatabaseException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -151,7 +151,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -161,7 +161,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 
@@ -257,7 +257,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie($e->getMessage());
+            die($e->getMessage());
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Save Stripe Idempotency Key Error => ".$e->getMessage(),
@@ -267,7 +267,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Save Stripe Payment Intent Error => ".$e->getMessage(),
@@ -277,7 +277,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 
@@ -307,7 +307,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
                 );
                 ProcessLoggerHandler::closeLogger();
                 http_response_code(400);
-                $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+                die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
             }
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
@@ -318,7 +318,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            $this->ajaxDie('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
         }
     }
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -23,6 +23,7 @@
  * @license   Commercial license
  */
 
+use Stripe\PaymentIntent;
 use Stripe_officialClasslib\Extensions\ProcessLogger\ProcessLoggerHandler;
 
 class stripe_officialCreateIntentModuleFrontController extends ModuleFrontController
@@ -225,7 +226,10 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $stripeIdempotencyKey = new StripeIdempotencyKey();
             $stripeIdempotencyKey = $stripeIdempotencyKey->getByIdCart($cart->id);
 
-            if (empty($stripeIdempotencyKey->id) === true) {
+            $paymentIntentStatus = (empty($stripeIdempotencyKey->id) === false) ? PaymentIntent::retrieve($stripeIdempotencyKey->id_payment_intent)->status : null;
+            $updatableStatus = ['requires_payment_method', 'requires_confirmation', 'requires_action'];
+
+            if (in_array($paymentIntentStatus, $updatableStatus) === false) {
                 $intent = $stripeIdempotencyKey->createNewOne($cart->id, $intentData);
                 $this->registerStripeEvent($intent);
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -67,7 +67,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         }
 
         ProcessLoggerHandler::logInfo(
@@ -142,7 +142,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         } catch (PrestaShopDatabaseException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -152,7 +152,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
                 "Retrieve Prestashop State Error => ".$e->getMessage(),
@@ -162,7 +162,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         }
     }
 
@@ -271,17 +271,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
-        } catch (PrestaShopException $e) {
-            ProcessLoggerHandler::logError(
-                "Save Stripe Payment Intent Error => ".$e->getMessage(),
-                null,
-                null,
-                'createIntent - createIdempotencyKey'
-            );
-            ProcessLoggerHandler::closeLogger();
-            http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         }
     }
 
@@ -314,7 +304,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
                 );
                 ProcessLoggerHandler::closeLogger();
                 http_response_code(400);
-                die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+                die('An unexpected problem has occurred. Please contact the support.');
             }
         } catch (PrestaShopException $e) {
             ProcessLoggerHandler::logError(
@@ -325,7 +315,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             );
             ProcessLoggerHandler::closeLogger();
             http_response_code(400);
-            die('An unexpected problem has occurred. Please contact the support : https://addons.prestashop.com/en/contact-us?id_product=24922');
+            die('An unexpected problem has occurred. Please contact the support.');
         }
     }
 

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -284,10 +284,13 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
     private function registerStripeEvent($intent)
     {
         try {
+            $stripeEventDate = new DateTime();
+            $stripeEventDate = $stripeEventDate->setTimestamp($intent->created);
+
             $stripeEvent = new StripeEvent();
             $stripeEvent->setIdPaymentIntent($intent->id);
             $stripeEvent->setStatus(StripeEvent::CREATED_STATUS);
-            $stripeEvent->setDateAdd($intent->created);
+            $stripeEvent->setDateAdd($stripeEventDate);
             $stripeEvent->setIsProcessed(1);
             $stripeEvent->setFlowType('direct');
 


### PR DESCRIPTION
Some client with cart created before release 2.4.3 cannot pay order because the payment intent related to this cart cannot be updated.