### PR TITLE
Fix payment intent update error with an other payment method after failed of card payment

### DIFF
--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -226,10 +226,14 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $stripeIdempotencyKey = new StripeIdempotencyKey();
             $stripeIdempotencyKey = $stripeIdempotencyKey->getByIdCart($cart->id);
 
-            $paymentIntentStatus = (empty($stripeIdempotencyKey->id) === false) ? PaymentIntent::retrieve($stripeIdempotencyKey->id_payment_intent)->status : null;
+            $previousPaymentIntentData = PaymentIntent::retrieve($stripeIdempotencyKey->id_payment_intent);
+
+            $paymentIntentStatus = (empty($stripeIdempotencyKey->id) === false) ? $previousPaymentIntentData->status : null;
             $updatableStatus = ['requires_payment_method', 'requires_confirmation', 'requires_action'];
 
-            if (in_array($paymentIntentStatus, $updatableStatus) === false) {
+            if (in_array($paymentIntentStatus, $updatableStatus) === false
+                || $previousPaymentIntentData->capture_method !== $intentData['capture_method']
+            ) {
                 $intent = $stripeIdempotencyKey->createNewOne($cart->id, $intentData);
                 $this->registerStripeEvent($intent);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | During a payment attempt by Bancontact after having attempted a payment by card which failed, the Stripe API reports an error about capture method set to automatic which prevents the new payment attempt.
| Type?         | bugfix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 35025
| How to test?  | Create an order and pay with Stripe<br>go to the Stripe Dashboard and withdraw it partially.