### PR TITLE
Fix capture error during payment with card

### DIFF
--- a/classes/actions/ValidationOrderActions.php
+++ b/classes/actions/ValidationOrderActions.php
@@ -376,7 +376,9 @@ class ValidationOrderActions extends DefaultActions
                 'ValidationOrderActions - createOrder'
             );
 
-            if ($intent->payment_method_types[0] == 'card' && Configuration::get(Stripe_official::CATCHANDAUTHORIZE) == null) {
+            if ($intent->payment_method_types[0] == 'card'
+                && $intent->capture_method != 'automatic'
+                && Configuration::get(Stripe_official::CATCHANDAUTHORIZE) == null) {
                 ProcessLoggerHandler::logInfo(
                     'Capturing card',
                     null,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the payment intent is in automatic capture mode with a card payment method, an error occurs in the ValidationOrderActions class because an attempt is made to capture the payment manually. This happens after a previous attempt with a different payment method.
| Type?         | bugfix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 35018