### PR TITLE
Fix webhook url validation in multishop context on PS 1.7

### DIFF
--- a/classes/StripeWebhook.php
+++ b/classes/StripeWebhook.php
@@ -30,20 +30,12 @@ class StripeWebhook extends ObjectModel
     public static function create()
     {
         try {
-            $context = Context::getContext();
             $shopGroupId = Stripe_official::getShopGroupIdContext();
             $shopId = Stripe_official::getShopIdContext();
 
             $stripeAccount = \Stripe\Account::retrieve();
             $webhookEndpoint = \Stripe\WebhookEndpoint::create([
-                'url' => $context->link->getModuleLink(
-                    'stripe_official',
-                    'webhook',
-                    array(),
-                    true,
-                    Configuration::get('PS_LANG_DEFAULT'),
-                    $shopId ?: Configuration::get('PS_SHOP_DEFAULT')
-                ),
+                'url' => Stripe_official::getWebhookUrl(),
                 'enabled_events' => Stripe_official::$webhook_events,
             ]);
 
@@ -97,14 +89,7 @@ class StripeWebhook extends ObjectModel
         }
 
         $webhooksList = self::getWebhookList();
-        $webhookUrl = $context->link->getModuleLink(
-            'stripe_official',
-            'webhook',
-            array(),
-            true,
-            Configuration::get('PS_LANG_DEFAULT'),
-            Stripe_official::getShopIdContext() ?: Configuration::get('PS_SHOP_DEFAULT')
-        );
+        $webhookUrl = Stripe_official::getWebhookUrl();
         $webhookExists = false;
 
         foreach ($webhooksList->data as $webhook) {

--- a/classes/actions/ConfigurationActions.php
+++ b/classes/actions/ConfigurationActions.php
@@ -207,7 +207,7 @@ class ConfigurationActions extends DefaultActions
             /* Check if webhook access is write */
             try {
                 $webhookEndpoint = \Stripe\WebhookEndpoint::retrieve($webhookId);
-                $webhookUrlExpected = $this->context->link->getModuleLink('stripe_official', 'webhook', array(), true, Configuration::get('PS_LANG_DEFAULT'), Stripe_official::getShopIdContext() ?: Configuration::get('PS_SHOP_DEFAULT'));
+                $webhookUrlExpected = Stripe_official::getWebhookUrl();
                 $webhookUpdateData = [];
 
                 /* Check if webhook configuration is wrong */
@@ -242,7 +242,7 @@ class ConfigurationActions extends DefaultActions
             $webhooksList = StripeWebhook::getWebhookList();
 
             foreach ($webhooksList as $webhookEndpoint) {
-                if ($webhookEndpoint->url == $this->context->link->getModuleLink('stripe_official', 'webhook', array(), true, Configuration::get('PS_LANG_DEFAULT'), Stripe_official::getShopIdContext() ?: Configuration::get('PS_SHOP_DEFAULT'))) {
+                if ($webhookEndpoint->url == Stripe_official::getWebhookUrl()) {
                     $webhookEndpoint->delete();
                 }
             }

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -889,7 +889,7 @@ class Stripe_official extends PaymentModule
                 $webhookEndpoint = \Stripe\WebhookEndpoint::retrieve($webhookId);
 
                 /* Check if webhook url is wrong */
-                $expectedWebhookUrl = $this->context->link->getModuleLink('stripe_official', 'webhook', array(), true, Configuration::get('PS_LANG_DEFAULT'), Stripe_official::getShopIdContext() ?: Configuration::get('PS_SHOP_DEFAULT'));
+                $expectedWebhookUrl = self::getWebhookUrl();
                 if ($webhookEndpoint->url != $expectedWebhookUrl) {
                     $this->errors[] =
                         $this->l('Webhook URL configuration is wrong, click on save button to fix issue. Webhook configuration will be corrected.', $this->name) .' | '.
@@ -1075,7 +1075,7 @@ class Stripe_official extends PaymentModule
             'alipay' => Configuration::get(self::ENABLE_ALIPAY,null, $shopGroupId, $shopId),
             'oxxo' => Configuration::get(self::ENABLE_OXXO,null, $shopGroupId, $shopId),
             'applepay_googlepay' => Configuration::get(self::ENABLE_APPLEPAY_GOOGLEPAY,null, $shopGroupId, $shopId),
-            'url_webhhoks' => $this->context->link->getModuleLink($this->name, 'webhook', array(), true, Configuration::get('PS_LANG_DEFAULT'), Stripe_official::getShopIdContext() ?: Configuration::get('PS_SHOP_DEFAULT')),
+            'url_webhhoks' => self::getWebhookUrl(),
         ));
     }
 
@@ -1306,6 +1306,40 @@ class Stripe_official extends PaymentModule
         foreach ($templates as $tpl) {
             $this->_clearCache($tpl);
         }
+    }
+
+    /**
+     * get webhook url of stripe_official module
+     *
+     * @return string
+     */
+    public static function getWebhookUrl()
+    {
+        $context = Context::getContext();
+        $id_lang = self::getLangIdContext();
+        $id_shop = self::getShopIdContext();
+
+        return $context->link->getModuleLink(
+            'stripe_official',
+            'webhook',
+            [],
+            true,
+            $id_lang,
+            $id_shop
+        );
+    }
+
+    /**
+     * get current LangId according to activate multishop feature
+     *
+     * @return int|null
+     */
+    public static function getLangIdContext()
+    {
+        if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && Shop::getContext() === Shop::CONTEXT_ALL) {
+            return Configuration::get('PS_LANG_DEFAULT', null, 1, 1);
+        }
+        return Configuration::get('PS_LANG_DEFAULT');
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On Prestashop 1.7.8.x, there is an issue to save configurations in All Shop Context.
| Type?         | fixbug 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 34319
| How to test?  | 
