### PR TITLE
Fix transition for partial refund statuses in webhook

### DIFF
--- a/classes/actions/ValidationOrderActions.php
+++ b/classes/actions/ValidationOrderActions.php
@@ -813,15 +813,7 @@ class ValidationOrderActions extends DefaultActions
                 break;
 
             case 'charge.refunded':
-                if ($order->getCurrentState() != Configuration::get('PS_OS_PAYMENT')) {
-                    $order->setCurrentState(Configuration::get('PS_OS_CANCELED'));
-                    ProcessLoggerHandler::logInfo(
-                        'Order canceled',
-                        null,
-                        null,
-                        'ValidationOrderActions - chargeWebhook'
-                    );
-                } else {
+                if ($order->getCurrentState() == Configuration::get('PS_OS_PAYMENT')) {
                     if ($this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount_captured
                         || $this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount) {
                         $order->setCurrentState(Configuration::get('PS_CHECKOUT_STATE_PARTIAL_REFUND'));

--- a/classes/actions/ValidationOrderActions.php
+++ b/classes/actions/ValidationOrderActions.php
@@ -814,7 +814,7 @@ class ValidationOrderActions extends DefaultActions
 
             case 'charge.refunded':
                 $currentState = new \OrderState($order->getCurrentState());
-                if ($currentState->paid === true) {
+                if ((bool) $currentState->paid === true) {
                     if ($this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount_captured
                         || $this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount) {
                         $order->setCurrentState(Configuration::get('PS_CHECKOUT_STATE_PARTIAL_REFUND'));

--- a/classes/actions/ValidationOrderActions.php
+++ b/classes/actions/ValidationOrderActions.php
@@ -813,7 +813,8 @@ class ValidationOrderActions extends DefaultActions
                 break;
 
             case 'charge.refunded':
-                if ($order->getCurrentState() == Configuration::get('PS_OS_PAYMENT')) {
+                $currentState = new \OrderState($order->getCurrentState());
+                if ($currentState->paid === true) {
                     if ($this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount_captured
                         || $this->conveyor['event_json']->data->object->amount_refunded !== $this->conveyor['event_json']->data->object->amount) {
                         $order->setCurrentState(Configuration::get('PS_CHECKOUT_STATE_PARTIAL_REFUND'));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When an order is refund or partially refund, the PrestaShop module cancel the order instead of withdraw it.
| Type?         | bugfix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [34683]
| How to test?  | Create an order and pay with Stripe<br>go to the Stripe Dashboard and withdraw it partially.