### PR TITLE
Fix saved card display in payment option page

### DIFF
--- a/classes/StripeCustomer.php
+++ b/classes/StripeCustomer.php
@@ -92,7 +92,7 @@ class StripeCustomer extends ObjectModel
         $query->select('*');
         $query->from(static::$definition['table']);
         $query->where('id_customer = ' . pSQL((int) $id_customer));
-        $query->where('id_account = "' . pSQL((int) $id_account) . '"');
+        $query->where('id_account = "' . pSQL((string) $id_account) . '"');
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query->build());
         if (empty($result) === true) {

--- a/classes/StripeCustomer.php
+++ b/classes/StripeCustomer.php
@@ -91,8 +91,8 @@ class StripeCustomer extends ObjectModel
         $query = new DbQuery();
         $query->select('*');
         $query->from(static::$definition['table']);
-        $query->where('id_customer = ' . pSQL((int) $id_customer));
-        $query->where('id_account = "' . pSQL((string) $id_account) . '"');
+        $query->where('id_customer = ' . (int) $id_customer);
+        $query->where('id_account = "' . pSQL($id_account) . '"');
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query->build());
         if (empty($result) === true) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Stripe Official PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Functionality regression of displaying credit cards saved from previous purchases.<br>They are no longer present when displaying payment methods.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #36438
| How to test?  | Going to payment method page in front and check if saved card are displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
