### PR TITLE
Custom hook to define stripe metadata (27526)

### DIFF
--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -96,14 +96,18 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $shippingAddress = new Address($this->context->cart->id_address_delivery);
             $shippingAddressState = new State($shippingAddress->id_state);
 
+            $metadata = [];
+
+            Hook::exec('actionStripeOfficialMetadataDefinition', $metadata);
+
+            $metadata['id_cart'] = $this->context->cart->id;
+
             $intentData = [
                 'amount' => $amount,
                 'currency' => $currency,
                 'payment_method_types' => [$paymentOption],
                 'capture_method' => $captureMethod,
-                'metadata' => [
-                    'id_cart' => $this->context->cart->id,
-                ],
+                'metadata' => $metadata,
                 'description' => 'Product Purchase',
                 'shipping' => [
                     'name' => $customerFullName,

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -96,11 +96,10 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $shippingAddress = new Address($this->context->cart->id_address_delivery);
             $shippingAddressState = new State($shippingAddress->id_state);
 
-            $metadata = [];
-
-            Hook::exec('actionStripeOfficialMetadataDefinition', $metadata);
-
-            $metadata['id_cart'] = $this->context->cart->id;
+            $metadata = Hook::exec(
+                'actionStripeOfficialMetadataDefinition',
+                ['id_cart' => $this->context->cart->id]
+            );
 
             $intentData = [
                 'amount' => $amount,

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -96,10 +96,8 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $shippingAddress = new Address($this->context->cart->id_address_delivery);
             $shippingAddressState = new State($shippingAddress->id_state);
 
-            $metadata = Hook::exec(
-                'actionStripeOfficialMetadataDefinition',
-                ['id_cart' => $this->context->cart->id]
-            );
+            $metadata = ['id_cart' => $this->context->cart->id];
+            Hook::exec('actionStripeOfficialMetadataDefinition', &$metadata);
 
             $intentData = [
                 'amount' => $amount,

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -97,7 +97,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             $shippingAddressState = new State($shippingAddress->id_state);
 
             $metadata = ['id_cart' => $this->context->cart->id];
-            Hook::exec('actionStripeOfficialMetadataDefinition', &$metadata);
+            Hook::exec('actionStripeOfficialMetadataDefinition', ['metadata' => &$metadata]);
 
             $intentData = [
                 'amount' => $amount,

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -521,7 +521,7 @@ class Stripe_official extends PaymentModule
                 $name = 'actionStripeOfficialAddPaymentIntent';
                 $title = 'Define metadata of Stripe payment intent';
                 $description = 'Metadata is passing during creation and update of Stripe payment intent';
-                $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'hook` (`name`, `title`, `description`) VALUES ("' . $name . '", "' . $title . '", "' . $description . '");';
+                $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'hook` (`name`, `title`, `description`) VALUES ("' . pSQL($name) . '", "' . pSQL($title) . '", "' . pSQL($description) . '");';
                 Db::getInstance()->execute($sql);
             }
 

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -517,7 +517,7 @@ class Stripe_official extends PaymentModule
                 Db::getInstance()->execute($sql);
             }
 
-            if (Hook::getHookStatusByName('actionStripeOfficialMetadataDefinition') === false) {
+            if (Hook::getIdByName('actionStripeOfficialMetadataDefinition') === false) {
                 $name = 'actionStripeOfficialAddPaymentIntent';
                 $title = 'Define metadata of Stripe payment intent';
                 $description = 'Metadata is passing during creation and update of Stripe payment intent';

--- a/stripe_official.php
+++ b/stripe_official.php
@@ -517,6 +517,14 @@ class Stripe_official extends PaymentModule
                 Db::getInstance()->execute($sql);
             }
 
+            if (Hook::getHookStatusByName('actionStripeOfficialMetadataDefinition') === false) {
+                $name = 'actionStripeOfficialAddPaymentIntent';
+                $title = 'Define metadata of Stripe payment intent';
+                $description = 'Metadata is passing during creation and update of Stripe payment intent';
+                $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'hook` (`name`, `title`, `description`) VALUES ("' . $name . '", "' . $title . '", "' . $description . '");';
+                Db::getInstance()->execute($sql);
+            }
+
             $shopGroupId = Stripe_official::getShopGroupIdContext();
             $shopId = Stripe_official::getShopIdContext();
 
@@ -1436,8 +1444,6 @@ class Stripe_official extends PaymentModule
 
             return false;
         }
-
-        return true;
     }
 
     public function updateConfigurationKey($oldKey, $newKey)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Stripe Official PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | add hook to define custom metadata during Stripe payment
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Evol #27526.
| How to test?  | Use actionStripeOfficialMetadataDefinition hook in other module to add custom metadata to stripe payment.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
