### PR TITLE
Fix no such payment intent error about module mode (37132)

### DIFF
--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -235,7 +235,7 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
             }
         } catch (\Stripe\Exception\ApiErrorException $e) {
             ProcessLoggerHandler::logInfo(
-                "Cannot retrieve Stripe Intent => ".$e->getMessage(),
+                'Cannot retrieve Stripe Intent => ' . $e->getMessage(),
                 null,
                 null,
                 'createIntent - createIdempotencyKey'

--- a/controllers/front/createIntent.php
+++ b/controllers/front/createIntent.php
@@ -220,11 +220,11 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
 
     private function createIdempotencyKey($intentData)
     {
-        try {
-            $cart = $this->context->cart;
-            $stripeIdempotencyKey = new StripeIdempotencyKey();
-            $stripeIdempotencyKey = $stripeIdempotencyKey->getByIdCart($cart->id);
+        $cart = $this->context->cart;
+        $stripeIdempotencyKey = new StripeIdempotencyKey();
+        $stripeIdempotencyKey = $stripeIdempotencyKey->getByIdCart($cart->id);
 
+        try {
             if (empty($stripeIdempotencyKey->id) === false) {
                 $previousPaymentIntentData = PaymentIntent::retrieve($stripeIdempotencyKey->id_payment_intent);
                 $paymentIntentStatus = $previousPaymentIntentData->status;
@@ -233,9 +233,20 @@ class stripe_officialCreateIntentModuleFrontController extends ModuleFrontContro
                 $paymentIntentStatus = null;
                 $paymentIntentCaptureMethod = null;
             }
+        } catch (\Stripe\Exception\ApiErrorException $e) {
+            ProcessLoggerHandler::logInfo(
+                "Cannot retrieve Stripe Intent => ".$e->getMessage(),
+                null,
+                null,
+                'createIntent - createIdempotencyKey'
+            );
+            $paymentIntentStatus = null;
+            $paymentIntentCaptureMethod = null;
+        }
 
-            $updatableStatus = ['requires_payment_method', 'requires_confirmation', 'requires_action'];
+        $updatableStatus = ['requires_payment_method', 'requires_confirmation', 'requires_action'];
 
+        try {
             if (in_array($paymentIntentStatus, $updatableStatus) === false
                 || $paymentIntentCaptureMethod !== $intentData['capture_method']
             ) {


### PR DESCRIPTION
…other mode than current activated

<!-----------------------------------------------------------------------------
Thank you for contributing to the Stripe Official PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix create intent when a payment intent was begin in an other mode than current activated
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #37132
| How to test?  | Do payment error in test mode and do payment in prod mode with same cart

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
